### PR TITLE
Table Schema

### DIFF
--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -702,6 +702,33 @@ env_to_df <- function(env){
 }
 
 
+build_table_schema <- function(  tbl, tbl_file ){
+  colnames <- names(tbl)
+  
+  
+  table_schema <- c()
+  
+  for( i in seq(1, length(colnames))) {
+    
+    entry <- list("kind"=unbox("ColumnSchema"),
+                  "name"=unbox(colnames[[i]]),
+                  "type"=unbox(get_column_type(class(tbl[[colnames[[i]]]]))) )
+    
+    table_schema <- append( table_schema, list(entry) )
+    
+  }
+  
+  json_data <- list("kind"=unbox("TableSchema"),
+                    "columns"=table_schema)
+  
+  
+  
+  json_data <- toJSON(json_data, pretty=TRUE, auto_unbox = FALSE,
+                      digits=16)
+  
+  write(json_data, str_replace(tbl_file, ".csv", ".csv.schema") )
+}
+
 get_column_type <- function(coltype){
   schematype <- NULL
   schematype <- switch(coltype,

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -700,3 +700,14 @@ env_to_df <- function(env){
   
   return(dff)
 }
+
+
+get_column_type <- function(coltype){
+  schematype <- NULL
+  schematype <- switch(coltype,
+                       "character"="string",
+                       "numeric"="double",
+                       "integer"="int32")
+  
+  return(schematype)
+}

--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -204,6 +204,10 @@ build_test_for_table <- function( in_proj, res_table, ctx, test_name,
   tidx <- 1
   out_tbl_files <- append( out_tbl_files, 
                            unbox(paste0(test_name, '_out_', tidx, '.csv') ))
+  
+  build_table_schema(as.data.frame(res_table),
+                     file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ))
+  
   write.csv(res_table,
             file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
             row.names = FALSE)
@@ -223,6 +227,8 @@ build_test_for_table <- function( in_proj, res_table, ctx, test_name,
       }
     }
     
+    build_table_schema(out_ctbl %>% select(-".ci"),
+                       file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) )
     
     write.csv(out_ctbl %>% select(-".ci"),
               file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
@@ -244,6 +250,9 @@ build_test_for_table <- function( in_proj, res_table, ctx, test_name,
       }
     }
     
+    
+    build_table_schema(out_rtbl %>% select(-".ri"),
+                       file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) )
     
     write.csv(out_rtbl %>% select(-".ri"),
               file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
@@ -277,6 +286,10 @@ build_test_for_table_list <- function( in_proj, res_table_list, ctx, test_name,
     
     out_tbl_files <- append( out_tbl_files, 
                              unbox(paste0(test_name, '_out_', tidx, '.csv') ))
+    
+    build_table_schema(as.data.frame(res_table),
+                       file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ))
+    
     write.csv(res_table,
               file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
               row.names = FALSE)
@@ -296,6 +309,10 @@ build_test_for_table_list <- function( in_proj, res_table_list, ctx, test_name,
             mutate_all( ~str_replace(., unlist(names(docIdMapping[i])), unname(docIdMapping[i])) )
         }
       }
+      
+      build_table_schema(out_ctbl %>% select(-".ci"),
+                         file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) )
+      
       write.csv(out_ctbl %>% select(-".ci"),
                 file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
                 row.names = FALSE)
@@ -314,6 +331,9 @@ build_test_for_table_list <- function( in_proj, res_table_list, ctx, test_name,
             mutate_all( ~str_replace(., unlist(names(docIdMapping[i])), unname(docIdMapping[i])) )
         }
       }
+      
+      build_table_schema(out_rtbl %>% select(-".ri"),
+                         file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) )
       
       write.csv(out_rtbl %>% select(-".ri"),
                 file.path(test_folder, paste0(test_name, '_out_', tidx, '.csv') ) ,
@@ -382,9 +402,15 @@ build_test_data_for_schema <- function( in_proj, res_table, ctx, test_name,
   for( k in seq(1, length(out_tbls))){
     out_tbl_files <- append( out_tbl_files, 
                              unbox(paste0(test_name, '_out_', k ,'.csv') ))
+    
+    
     write.csv(as.data.frame(out_tbls[[k]]),
               file.path(test_folder, paste0(test_name, '_out_', k ,'.csv') ) ,
               row.names = FALSE)
+    
+    build_table_schema(as.data.frame(out_tbls[[k]]),
+                       file.path(test_folder, paste0(test_name, '_out_', k ,'.csv') ))
+    
   }
   
   return(out_tbl_files)


### PR DESCRIPTION
For all tests, the matching table schema is now created. This prevents data mismatch, specially with integer columns (as was the case with the pca_operator)